### PR TITLE
revise API technical doc to match API change

### DIFF
--- a/docs/api_technical_doc.html
+++ b/docs/api_technical_doc.html
@@ -122,9 +122,9 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </header>
 
 
-<div id="13245221" class="cell" data-execution_count="1">
+<div id="1af0cb3e" class="cell" data-execution_count="1">
 <div class="cell-output cell-output-stdout">
-<pre><code>December 17, 2024</code></pre>
+<pre><code>January 21, 2025</code></pre>
 </div>
 </div>
 <section id="introduction" class="level2">
@@ -224,17 +224,17 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb3-12"><a href="#cb3-12" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
 <span id="cb3-13"><a href="#cb3-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_description"</span><span class="fu">:</span> <span class="st">"At-risk-of-poverty rate by NUTS 2 regions (ESTAT)"</span><span class="fu">,</span></span>
 <span id="cb3-14"><a href="#cb3-14" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_resource"</span><span class="fu">:</span> <span class="st">"TGS00103"</span><span class="fu">,</span></span>
-<span id="cb3-15"><a href="#cb3-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_short_description"</span><span class="fu">:</span> <span class="st">"At-risk-of-poverty r"</span></span>
+<span id="cb3-15"><a href="#cb3-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_short_description"</span><span class="fu">:</span> <span class="st">"At-risk-of-poverty"</span></span>
 <span id="cb3-16"><a href="#cb3-16" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
 <span id="cb3-17"><a href="#cb3-17" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
 <span id="cb3-18"><a href="#cb3-18" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_description"</span><span class="fu">:</span> <span class="st">"Available beds in hospitals by NUTS 2 region (ESTAT)"</span><span class="fu">,</span></span>
 <span id="cb3-19"><a href="#cb3-19" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_resource"</span><span class="fu">:</span> <span class="st">"HLTH_RS_BDSRG2"</span><span class="fu">,</span></span>
-<span id="cb3-20"><a href="#cb3-20" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_short_description"</span><span class="fu">:</span> <span class="st">"Available beds in ho"</span></span>
+<span id="cb3-20"><a href="#cb3-20" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_short_description"</span><span class="fu">:</span> <span class="st">"Hospital beds"</span></span>
 <span id="cb3-21"><a href="#cb3-21" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
 <span id="cb3-22"><a href="#cb3-22" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
 <span id="cb3-23"><a href="#cb3-23" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_description"</span><span class="fu">:</span> <span class="st">"Available beds in hospitals by NUTS 2 regions (ESTAT)"</span><span class="fu">,</span></span>
 <span id="cb3-24"><a href="#cb3-24" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_resource"</span><span class="fu">:</span> <span class="st">"TGS00064"</span><span class="fu">,</span></span>
-<span id="cb3-25"><a href="#cb3-25" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_short_description"</span><span class="fu">:</span> <span class="st">"Available beds in ho"</span></span>
+<span id="cb3-25"><a href="#cb3-25" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_short_description"</span><span class="fu">:</span> <span class="st">"Hospital beds"</span></span>
 <span id="cb3-26"><a href="#cb3-26" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
 <span id="cb3-27"><a href="#cb3-27" aria-hidden="true" tabindex="-1"></a><span class="ot">]</span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <p><em>Note: Only the first 5 json elements are shown</em></p>
@@ -269,17 +269,17 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
 <span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_description"</span><span class="fu">:</span> <span class="st">"At-risk-of-poverty rate by NUTS 2 regions (ESTAT)"</span><span class="fu">,</span></span>
 <span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_resource"</span><span class="fu">:</span> <span class="st">"TGS00103"</span><span class="fu">,</span></span>
-<span id="cb4-10"><a href="#cb4-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_short_description"</span><span class="fu">:</span> <span class="st">"At-risk-of-poverty r"</span></span>
+<span id="cb4-10"><a href="#cb4-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_short_description"</span><span class="fu">:</span> <span class="st">"At-risk-of-poverty"</span></span>
 <span id="cb4-11"><a href="#cb4-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
 <span id="cb4-12"><a href="#cb4-12" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
 <span id="cb4-13"><a href="#cb4-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_description"</span><span class="fu">:</span> <span class="st">"Available beds in hospitals by NUTS 2 region (ESTAT)"</span><span class="fu">,</span></span>
 <span id="cb4-14"><a href="#cb4-14" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_resource"</span><span class="fu">:</span> <span class="st">"HLTH_RS_BDSRG2"</span><span class="fu">,</span></span>
-<span id="cb4-15"><a href="#cb4-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_short_description"</span><span class="fu">:</span> <span class="st">"Available beds in ho"</span></span>
+<span id="cb4-15"><a href="#cb4-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_short_description"</span><span class="fu">:</span> <span class="st">"Hospital beds"</span></span>
 <span id="cb4-16"><a href="#cb4-16" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
 <span id="cb4-17"><a href="#cb4-17" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
 <span id="cb4-18"><a href="#cb4-18" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_description"</span><span class="fu">:</span> <span class="st">"Available beds in hospitals by NUTS 2 regions (ESTAT)"</span><span class="fu">,</span></span>
 <span id="cb4-19"><a href="#cb4-19" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_resource"</span><span class="fu">:</span> <span class="st">"TGS00064"</span><span class="fu">,</span></span>
-<span id="cb4-20"><a href="#cb4-20" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_short_description"</span><span class="fu">:</span> <span class="st">"Available beds in ho"</span></span>
+<span id="cb4-20"><a href="#cb4-20" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_short_description"</span><span class="fu">:</span> <span class="st">"Hospital beds"</span></span>
 <span id="cb4-21"><a href="#cb4-21" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
 <span id="cb4-22"><a href="#cb4-22" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
 <span id="cb4-23"><a href="#cb4-23" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"f_description"</span><span class="fu">:</span> <span class="st">"Business demography and high growth enterprise by NACE Rev. 2 and NUTS 3 regions (ESTAT)"</span><span class="fu">,</span></span>
@@ -410,12 +410,12 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb7-48"><a href="#cb7-48" aria-hidden="true" tabindex="-1"></a>                <span class="dt">"value"</span><span class="fu">:</span> <span class="st">"T"</span></span>
 <span id="cb7-49"><a href="#cb7-49" aria-hidden="true" tabindex="-1"></a>            <span class="fu">}</span><span class="ot">,</span></span>
 <span id="cb7-50"><a href="#cb7-50" aria-hidden="true" tabindex="-1"></a>            <span class="fu">{</span></span>
-<span id="cb7-51"><a href="#cb7-51" aria-hidden="true" tabindex="-1"></a>                <span class="dt">"label"</span><span class="fu">:</span> <span class="st">"Males"</span><span class="fu">,</span></span>
-<span id="cb7-52"><a href="#cb7-52" aria-hidden="true" tabindex="-1"></a>                <span class="dt">"value"</span><span class="fu">:</span> <span class="st">"M"</span></span>
+<span id="cb7-51"><a href="#cb7-51" aria-hidden="true" tabindex="-1"></a>                <span class="dt">"label"</span><span class="fu">:</span> <span class="st">"Females"</span><span class="fu">,</span></span>
+<span id="cb7-52"><a href="#cb7-52" aria-hidden="true" tabindex="-1"></a>                <span class="dt">"value"</span><span class="fu">:</span> <span class="st">"F"</span></span>
 <span id="cb7-53"><a href="#cb7-53" aria-hidden="true" tabindex="-1"></a>            <span class="fu">}</span><span class="ot">,</span></span>
 <span id="cb7-54"><a href="#cb7-54" aria-hidden="true" tabindex="-1"></a>            <span class="fu">{</span></span>
-<span id="cb7-55"><a href="#cb7-55" aria-hidden="true" tabindex="-1"></a>                <span class="dt">"label"</span><span class="fu">:</span> <span class="st">"Females"</span><span class="fu">,</span></span>
-<span id="cb7-56"><a href="#cb7-56" aria-hidden="true" tabindex="-1"></a>                <span class="dt">"value"</span><span class="fu">:</span> <span class="st">"F"</span></span>
+<span id="cb7-55"><a href="#cb7-55" aria-hidden="true" tabindex="-1"></a>                <span class="dt">"label"</span><span class="fu">:</span> <span class="st">"Males"</span><span class="fu">,</span></span>
+<span id="cb7-56"><a href="#cb7-56" aria-hidden="true" tabindex="-1"></a>                <span class="dt">"value"</span><span class="fu">:</span> <span class="st">"M"</span></span>
 <span id="cb7-57"><a href="#cb7-57" aria-hidden="true" tabindex="-1"></a>            <span class="fu">}</span></span>
 <span id="cb7-58"><a href="#cb7-58" aria-hidden="true" tabindex="-1"></a>        <span class="ot">]</span></span>
 <span id="cb7-59"><a href="#cb7-59" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
@@ -581,36 +581,51 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <h4 class="anchored" data-anchor-id="returns-5">Returns:</h4>
 <div class="sourceCode" id="cb12"><pre class="sourceCode json code-with-copy"><code class="sourceCode json"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="ot">[</span></span>
 <span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
-<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"best_year"</span><span class="fu">:</span> <span class="st">"2021"</span><span class="fu">,</span></span>
-<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AL01"</span><span class="fu">,</span></span>
-<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Veri"</span><span class="fu">,</span></span>
-<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"x"</span><span class="fu">:</span> <span class="kw">null</span></span>
-<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
-<span id="cb12-9"><a href="#cb12-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"best_year"</span><span class="fu">:</span> <span class="st">"2021"</span><span class="fu">,</span></span>
-<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AL02"</span><span class="fu">,</span></span>
-<span id="cb12-11"><a href="#cb12-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Qender"</span><span class="fu">,</span></span>
-<span id="cb12-12"><a href="#cb12-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"x"</span><span class="fu">:</span> <span class="kw">null</span></span>
-<span id="cb12-13"><a href="#cb12-13" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb12-14"><a href="#cb12-14" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
-<span id="cb12-15"><a href="#cb12-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"best_year"</span><span class="fu">:</span> <span class="st">"2021"</span><span class="fu">,</span></span>
-<span id="cb12-16"><a href="#cb12-16" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AL03"</span><span class="fu">,</span></span>
-<span id="cb12-17"><a href="#cb12-17" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Jug"</span><span class="fu">,</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AL01"</span><span class="fu">,</span></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Veri"</span><span class="fu">,</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_source"</span><span class="fu">:</span> <span class="st">"NUTS"</span><span class="fu">,</span></span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_year"</span><span class="fu">:</span> <span class="st">"2021"</span><span class="fu">,</span></span>
+<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"outcome_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"predictor_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb12-9"><a href="#cb12-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"x"</span><span class="fu">:</span> <span class="kw">null</span></span>
+<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb12-11"><a href="#cb12-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb12-12"><a href="#cb12-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AL02"</span><span class="fu">,</span></span>
+<span id="cb12-13"><a href="#cb12-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Qender"</span><span class="fu">,</span></span>
+<span id="cb12-14"><a href="#cb12-14" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_source"</span><span class="fu">:</span> <span class="st">"NUTS"</span><span class="fu">,</span></span>
+<span id="cb12-15"><a href="#cb12-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_year"</span><span class="fu">:</span> <span class="st">"2021"</span><span class="fu">,</span></span>
+<span id="cb12-16"><a href="#cb12-16" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"outcome_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb12-17"><a href="#cb12-17" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"predictor_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
 <span id="cb12-18"><a href="#cb12-18" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"x"</span><span class="fu">:</span> <span class="kw">null</span></span>
 <span id="cb12-19"><a href="#cb12-19" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
 <span id="cb12-20"><a href="#cb12-20" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
-<span id="cb12-21"><a href="#cb12-21" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"best_year"</span><span class="fu">:</span> <span class="st">"2021"</span><span class="fu">,</span></span>
-<span id="cb12-22"><a href="#cb12-22" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AT11"</span><span class="fu">,</span></span>
-<span id="cb12-23"><a href="#cb12-23" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Burgenland"</span><span class="fu">,</span></span>
-<span id="cb12-24"><a href="#cb12-24" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"x"</span><span class="fu">:</span> <span class="fl">4.2</span></span>
-<span id="cb12-25"><a href="#cb12-25" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb12-26"><a href="#cb12-26" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
-<span id="cb12-27"><a href="#cb12-27" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"best_year"</span><span class="fu">:</span> <span class="st">"2021"</span><span class="fu">,</span></span>
-<span id="cb12-28"><a href="#cb12-28" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AT12"</span><span class="fu">,</span></span>
-<span id="cb12-29"><a href="#cb12-29" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Nieder</span><span class="ch">\u00f6</span><span class="st">sterreich"</span><span class="fu">,</span></span>
-<span id="cb12-30"><a href="#cb12-30" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"x"</span><span class="fu">:</span> <span class="fl">3.8</span></span>
-<span id="cb12-31"><a href="#cb12-31" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb12-32"><a href="#cb12-32" aria-hidden="true" tabindex="-1"></a><span class="ot">]</span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<span id="cb12-21"><a href="#cb12-21" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AL03"</span><span class="fu">,</span></span>
+<span id="cb12-22"><a href="#cb12-22" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Jug"</span><span class="fu">,</span></span>
+<span id="cb12-23"><a href="#cb12-23" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_source"</span><span class="fu">:</span> <span class="st">"NUTS"</span><span class="fu">,</span></span>
+<span id="cb12-24"><a href="#cb12-24" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_year"</span><span class="fu">:</span> <span class="st">"2021"</span><span class="fu">,</span></span>
+<span id="cb12-25"><a href="#cb12-25" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"outcome_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb12-26"><a href="#cb12-26" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"predictor_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb12-27"><a href="#cb12-27" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"x"</span><span class="fu">:</span> <span class="kw">null</span></span>
+<span id="cb12-28"><a href="#cb12-28" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb12-29"><a href="#cb12-29" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb12-30"><a href="#cb12-30" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AT11"</span><span class="fu">,</span></span>
+<span id="cb12-31"><a href="#cb12-31" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Burgenland"</span><span class="fu">,</span></span>
+<span id="cb12-32"><a href="#cb12-32" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_source"</span><span class="fu">:</span> <span class="st">"NUTS"</span><span class="fu">,</span></span>
+<span id="cb12-33"><a href="#cb12-33" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_year"</span><span class="fu">:</span> <span class="st">"2021"</span><span class="fu">,</span></span>
+<span id="cb12-34"><a href="#cb12-34" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"outcome_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb12-35"><a href="#cb12-35" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"predictor_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb12-36"><a href="#cb12-36" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"x"</span><span class="fu">:</span> <span class="fl">4.2</span></span>
+<span id="cb12-37"><a href="#cb12-37" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb12-38"><a href="#cb12-38" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb12-39"><a href="#cb12-39" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AT12"</span><span class="fu">,</span></span>
+<span id="cb12-40"><a href="#cb12-40" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Nieder</span><span class="ch">\u00f6</span><span class="st">sterreich"</span><span class="fu">,</span></span>
+<span id="cb12-41"><a href="#cb12-41" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_source"</span><span class="fu">:</span> <span class="st">"NUTS"</span><span class="fu">,</span></span>
+<span id="cb12-42"><a href="#cb12-42" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_year"</span><span class="fu">:</span> <span class="st">"2021"</span><span class="fu">,</span></span>
+<span id="cb12-43"><a href="#cb12-43" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"outcome_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb12-44"><a href="#cb12-44" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"predictor_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb12-45"><a href="#cb12-45" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"x"</span><span class="fu">:</span> <span class="fl">3.8</span></span>
+<span id="cb12-46"><a href="#cb12-46" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb12-47"><a href="#cb12-47" aria-hidden="true" tabindex="-1"></a><span class="ot">]</span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <p><em>Note: Only the first 5 json elements are shown</em></p>
 <hr>
 </section>
@@ -622,7 +637,8 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <h4 class="anchored" data-anchor-id="parameters-6">Parameters:</h4>
 <ul>
 <li><strong>_level</strong>: Geographic level</li>
-<li><strong>_year</strong>: Year of data</li>
+<li><strong>_predictor_year</strong>: Year of predictor (X) data</li>
+<li><strong>_outcome_year</strong>: Year of outcome (Y) data</li>
 <li><strong>X_JSON</strong>: JSON specifying the first source and filters.</li>
 <li><strong>Y_JSON</strong>: JSON specifying the second source and filters.</li>
 </ul>
@@ -630,7 +646,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <section id="example-call-8" class="level4">
 <h4 class="anchored" data-anchor-id="example-call-8">Example Call:</h4>
 <div class="wrapped-url">
-<p><a href="https://api.mapineq.org/functions/postgisftw.get_xy_data/items.json?_level=2&amp;_year=2018&amp;X_JSON={&quot;source&quot;:&quot;TGS00010&quot;,&quot;conditions&quot;:[{&quot;field&quot;:&quot;isced11&quot;,&quot;value&quot;:&quot;TOTAL&quot;},{&quot;field&quot;:&quot;unit&quot;,&quot;value&quot;:&quot;PC&quot;},{&quot;field&quot;:&quot;age&quot;,&quot;value&quot;:&quot;Y_GE15&quot;},{&quot;field&quot;:&quot;sex&quot;,&quot;value&quot;:&quot;T&quot;},{&quot;field&quot;:&quot;freq&quot;,&quot;value&quot;:&quot;A&quot;}]}&amp;Y_JSON={&quot;source&quot;:&quot;DEMO_R_MLIFEXP&quot;,&quot;conditions&quot;:[{&quot;field&quot;:&quot;unit&quot;,&quot;value&quot;:&quot;YR&quot;},{&quot;field&quot;:&quot;age&quot;,&quot;value&quot;:&quot;Y_LT1&quot;},{&quot;field&quot;:&quot;sex&quot;,&quot;value&quot;:&quot;T&quot;},{&quot;field&quot;:&quot;freq&quot;,&quot;value&quot;:&quot;A&quot;}]}&amp;limit=1500" target="_blank"> https://api.mapineq.org/functions/postgisftw.get_xy_data/items.json?_level=2&amp;_year=2018&amp;X_JSON={“source”:“TGS00010”,“conditions”:[{“field”:“isced11”,“value”:“TOTAL”},{“field”:“unit”,“value”:“PC”},{“field”:“age”,“value”:“Y_GE15”},{“field”:“sex”,“value”:“T”},{“field”:“freq”,“value”:“A”}]}&amp;Y_JSON={“source”:“DEMO_R_MLIFEXP”,“conditions”:[{“field”:“unit”,“value”:“YR”},{“field”:“age”,“value”:“Y_LT1”},{“field”:“sex”,“value”:“T”},{“field”:“freq”,“value”:“A”}]}&amp;limit=1500 </a></p>
+<p><a href="https://api.mapineq.org/functions/postgisftw.get_xy_data/items.json?_level=2&amp;_predictor_year=2018&amp;_outcome_year=2018&amp;X_JSON={&quot;source&quot;:&quot;TGS00010&quot;,&quot;conditions&quot;:[{&quot;field&quot;:&quot;isced11&quot;,&quot;value&quot;:&quot;TOTAL&quot;},{&quot;field&quot;:&quot;unit&quot;,&quot;value&quot;:&quot;PC&quot;},{&quot;field&quot;:&quot;age&quot;,&quot;value&quot;:&quot;Y_GE15&quot;},{&quot;field&quot;:&quot;sex&quot;,&quot;value&quot;:&quot;T&quot;},{&quot;field&quot;:&quot;freq&quot;,&quot;value&quot;:&quot;A&quot;}]}&amp;Y_JSON={&quot;source&quot;:&quot;DEMO_R_MLIFEXP&quot;,&quot;conditions&quot;:[{&quot;field&quot;:&quot;unit&quot;,&quot;value&quot;:&quot;YR&quot;},{&quot;field&quot;:&quot;age&quot;,&quot;value&quot;:&quot;Y_LT1&quot;},{&quot;field&quot;:&quot;sex&quot;,&quot;value&quot;:&quot;T&quot;},{&quot;field&quot;:&quot;freq&quot;,&quot;value&quot;:&quot;A&quot;}]}&amp;limit=1500" target="_blank"> https://api.mapineq.org/functions/postgisftw.get_xy_data/items.json?_level=2&amp;_predictor_year=2018&amp;_outcome_year=2018&amp;X_JSON={“source”:“TGS00010”,“conditions”:[{“field”:“isced11”,“value”:“TOTAL”},{“field”:“unit”,“value”:“PC”},{“field”:“age”,“value”:“Y_GE15”},{“field”:“sex”,“value”:“T”},{“field”:“freq”,“value”:“A”}]}&amp;Y_JSON={“source”:“DEMO_R_MLIFEXP”,“conditions”:[{“field”:“unit”,“value”:“YR”},{“field”:“age”,“value”:“Y_LT1”},{“field”:“sex”,“value”:“T”},{“field”:“freq”,“value”:“A”}]}&amp;limit=1500 </a></p>
 </div>
 </section>
 <section id="returns-6" class="level4">
@@ -638,41 +654,56 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <p>A list of geographic units with <strong>x</strong> and <strong>y</strong> values:</p>
 <div class="sourceCode" id="cb13"><pre class="sourceCode json code-with-copy"><code class="sourceCode json"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="ot">[</span></span>
 <span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
-<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"best_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
-<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AL01"</span><span class="fu">,</span></span>
-<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Veri"</span><span class="fu">,</span></span>
-<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"x"</span><span class="fu">:</span> <span class="kw">null</span><span class="fu">,</span></span>
-<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"y"</span><span class="fu">:</span> <span class="kw">null</span></span>
-<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
-<span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"best_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
-<span id="cb13-11"><a href="#cb13-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AL02"</span><span class="fu">,</span></span>
-<span id="cb13-12"><a href="#cb13-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Qender"</span><span class="fu">,</span></span>
-<span id="cb13-13"><a href="#cb13-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"x"</span><span class="fu">:</span> <span class="kw">null</span><span class="fu">,</span></span>
-<span id="cb13-14"><a href="#cb13-14" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"y"</span><span class="fu">:</span> <span class="kw">null</span></span>
-<span id="cb13-15"><a href="#cb13-15" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb13-16"><a href="#cb13-16" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
-<span id="cb13-17"><a href="#cb13-17" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"best_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
-<span id="cb13-18"><a href="#cb13-18" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AL03"</span><span class="fu">,</span></span>
-<span id="cb13-19"><a href="#cb13-19" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Jug"</span><span class="fu">,</span></span>
-<span id="cb13-20"><a href="#cb13-20" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"x"</span><span class="fu">:</span> <span class="kw">null</span><span class="fu">,</span></span>
-<span id="cb13-21"><a href="#cb13-21" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"y"</span><span class="fu">:</span> <span class="kw">null</span></span>
-<span id="cb13-22"><a href="#cb13-22" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb13-23"><a href="#cb13-23" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
-<span id="cb13-24"><a href="#cb13-24" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"best_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
-<span id="cb13-25"><a href="#cb13-25" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AT11"</span><span class="fu">,</span></span>
-<span id="cb13-26"><a href="#cb13-26" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Burgenland"</span><span class="fu">,</span></span>
-<span id="cb13-27"><a href="#cb13-27" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"x"</span><span class="fu">:</span> <span class="fl">4.2</span><span class="fu">,</span></span>
-<span id="cb13-28"><a href="#cb13-28" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"y"</span><span class="fu">:</span> <span class="fl">81.5</span></span>
-<span id="cb13-29"><a href="#cb13-29" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb13-30"><a href="#cb13-30" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
-<span id="cb13-31"><a href="#cb13-31" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"best_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
-<span id="cb13-32"><a href="#cb13-32" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AT12"</span><span class="fu">,</span></span>
-<span id="cb13-33"><a href="#cb13-33" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Nieder</span><span class="ch">\u00f6</span><span class="st">sterreich"</span><span class="fu">,</span></span>
-<span id="cb13-34"><a href="#cb13-34" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"x"</span><span class="fu">:</span> <span class="fl">3.8</span><span class="fu">,</span></span>
-<span id="cb13-35"><a href="#cb13-35" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"y"</span><span class="fu">:</span> <span class="fl">81.5</span></span>
-<span id="cb13-36"><a href="#cb13-36" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb13-37"><a href="#cb13-37" aria-hidden="true" tabindex="-1"></a><span class="ot">]</span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AL01"</span><span class="fu">,</span></span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Veri"</span><span class="fu">,</span></span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_source"</span><span class="fu">:</span> <span class="st">"NUTS"</span><span class="fu">,</span></span>
+<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"outcome_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"predictor_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"x"</span><span class="fu">:</span> <span class="kw">null</span><span class="fu">,</span></span>
+<span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"y"</span><span class="fu">:</span> <span class="kw">null</span></span>
+<span id="cb13-11"><a href="#cb13-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb13-12"><a href="#cb13-12" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb13-13"><a href="#cb13-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AL02"</span><span class="fu">,</span></span>
+<span id="cb13-14"><a href="#cb13-14" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Qender"</span><span class="fu">,</span></span>
+<span id="cb13-15"><a href="#cb13-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_source"</span><span class="fu">:</span> <span class="st">"NUTS"</span><span class="fu">,</span></span>
+<span id="cb13-16"><a href="#cb13-16" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb13-17"><a href="#cb13-17" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"outcome_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb13-18"><a href="#cb13-18" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"predictor_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb13-19"><a href="#cb13-19" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"x"</span><span class="fu">:</span> <span class="kw">null</span><span class="fu">,</span></span>
+<span id="cb13-20"><a href="#cb13-20" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"y"</span><span class="fu">:</span> <span class="kw">null</span></span>
+<span id="cb13-21"><a href="#cb13-21" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb13-22"><a href="#cb13-22" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb13-23"><a href="#cb13-23" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AL03"</span><span class="fu">,</span></span>
+<span id="cb13-24"><a href="#cb13-24" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Jug"</span><span class="fu">,</span></span>
+<span id="cb13-25"><a href="#cb13-25" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_source"</span><span class="fu">:</span> <span class="st">"NUTS"</span><span class="fu">,</span></span>
+<span id="cb13-26"><a href="#cb13-26" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb13-27"><a href="#cb13-27" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"outcome_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb13-28"><a href="#cb13-28" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"predictor_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb13-29"><a href="#cb13-29" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"x"</span><span class="fu">:</span> <span class="kw">null</span><span class="fu">,</span></span>
+<span id="cb13-30"><a href="#cb13-30" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"y"</span><span class="fu">:</span> <span class="kw">null</span></span>
+<span id="cb13-31"><a href="#cb13-31" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb13-32"><a href="#cb13-32" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb13-33"><a href="#cb13-33" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AT11"</span><span class="fu">,</span></span>
+<span id="cb13-34"><a href="#cb13-34" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Burgenland"</span><span class="fu">,</span></span>
+<span id="cb13-35"><a href="#cb13-35" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_source"</span><span class="fu">:</span> <span class="st">"NUTS"</span><span class="fu">,</span></span>
+<span id="cb13-36"><a href="#cb13-36" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb13-37"><a href="#cb13-37" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"outcome_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb13-38"><a href="#cb13-38" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"predictor_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb13-39"><a href="#cb13-39" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"x"</span><span class="fu">:</span> <span class="fl">4.2</span><span class="fu">,</span></span>
+<span id="cb13-40"><a href="#cb13-40" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"y"</span><span class="fu">:</span> <span class="fl">81.5</span></span>
+<span id="cb13-41"><a href="#cb13-41" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb13-42"><a href="#cb13-42" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb13-43"><a href="#cb13-43" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo"</span><span class="fu">:</span> <span class="st">"AT12"</span><span class="fu">,</span></span>
+<span id="cb13-44"><a href="#cb13-44" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_name"</span><span class="fu">:</span> <span class="st">"Nieder</span><span class="ch">\u00f6</span><span class="st">sterreich"</span><span class="fu">,</span></span>
+<span id="cb13-45"><a href="#cb13-45" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_source"</span><span class="fu">:</span> <span class="st">"NUTS"</span><span class="fu">,</span></span>
+<span id="cb13-46"><a href="#cb13-46" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"geo_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb13-47"><a href="#cb13-47" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"outcome_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb13-48"><a href="#cb13-48" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"predictor_year"</span><span class="fu">:</span> <span class="st">"2018"</span><span class="fu">,</span></span>
+<span id="cb13-49"><a href="#cb13-49" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"x"</span><span class="fu">:</span> <span class="fl">3.8</span><span class="fu">,</span></span>
+<span id="cb13-50"><a href="#cb13-50" aria-hidden="true" tabindex="-1"></a>        <span class="dt">"y"</span><span class="fu">:</span> <span class="fl">81.5</span></span>
+<span id="cb13-51"><a href="#cb13-51" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb13-52"><a href="#cb13-52" aria-hidden="true" tabindex="-1"></a><span class="ot">]</span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <p><em>Note: Only the first 5 json elements are shown</em></p>
 </section>
 </section>

--- a/docs/api_technical_doc.qmd
+++ b/docs/api_technical_doc.qmd
@@ -339,15 +339,16 @@ This endpoint allows you to retrieve data for two sources joined by location.
 
 #### Parameters:
 - **\_level**: Geographic level
-- **\_year**: Year of data
+- **\_predictor_year**: Year of predictor (X) data
+- **\_outcome_year**: Year of outcome (Y) data
 - **X_JSON**: JSON specifying the first source and filters.
 - **Y_JSON**: JSON specifying the second source and filters.
 
 #### Example Call:
 
 <div class="wrapped-url">
-  <a href='https://api.mapineq.org/functions/postgisftw.get_xy_data/items.json?_level=2&_year=2018&X_JSON={"source":"TGS00010","conditions":[{"field":"isced11","value":"TOTAL"},{"field":"unit","value":"PC"},{"field":"age","value":"Y_GE15"},{"field":"sex","value":"T"},{"field":"freq","value":"A"}]}&Y_JSON={"source":"DEMO_R_MLIFEXP","conditions":[{"field":"unit","value":"YR"},{"field":"age","value":"Y_LT1"},{"field":"sex","value":"T"},{"field":"freq","value":"A"}]}&limit=1500' target="_blank">
-    https://api.mapineq.org/functions/postgisftw.get_xy_data/items.json?_level=2&_year=2018&X_JSON={"source":"TGS00010","conditions":[{"field":"isced11","value":"TOTAL"},{"field":"unit","value":"PC"},{"field":"age","value":"Y_GE15"},{"field":"sex","value":"T"},{"field":"freq","value":"A"}]}&Y_JSON={"source":"DEMO_R_MLIFEXP","conditions":[{"field":"unit","value":"YR"},{"field":"age","value":"Y_LT1"},{"field":"sex","value":"T"},{"field":"freq","value":"A"}]}&limit=1500
+  <a href='https://api.mapineq.org/functions/postgisftw.get_xy_data/items.json?_level=2&_predictor_year=2018&_outcome_year=2018&X_JSON={"source":"TGS00010","conditions":[{"field":"isced11","value":"TOTAL"},{"field":"unit","value":"PC"},{"field":"age","value":"Y_GE15"},{"field":"sex","value":"T"},{"field":"freq","value":"A"}]}&Y_JSON={"source":"DEMO_R_MLIFEXP","conditions":[{"field":"unit","value":"YR"},{"field":"age","value":"Y_LT1"},{"field":"sex","value":"T"},{"field":"freq","value":"A"}]}&limit=1500' target="_blank">
+    https://api.mapineq.org/functions/postgisftw.get_xy_data/items.json?_level=2&_predictor_year=2018&_outcome_year=2018&X_JSON={"source":"TGS00010","conditions":[{"field":"isced11","value":"TOTAL"},{"field":"unit","value":"PC"},{"field":"age","value":"Y_GE15"},{"field":"sex","value":"T"},{"field":"freq","value":"A"}]}&Y_JSON={"source":"DEMO_R_MLIFEXP","conditions":[{"field":"unit","value":"YR"},{"field":"age","value":"Y_LT1"},{"field":"sex","value":"T"},{"field":"freq","value":"A"}]}&limit=1500
   </a>
 </div>
 
@@ -359,7 +360,7 @@ A list of geographic units with **x** and **y** values:
 # | echo: false
 # | output: asis
 print_json(
-    url='https://api.mapineq.org/functions/postgisftw.get_xy_data/items.json?_level=2&_year=2018&X_JSON={"source":"TGS00010","conditions":[{"field":"isced11","value":"TOTAL"},{"field":"unit","value":"PC"},{"field":"age","value":"Y_GE15"},{"field":"sex","value":"T"},{"field":"freq","value":"A"}]}&Y_JSON={"source":"DEMO_R_MLIFEXP","conditions":[{"field":"unit","value":"YR"},{"field":"age","value":"Y_LT1"},{"field":"sex","value":"T"},{"field":"freq","value":"A"}]}&limit=1500'
+    url='https://api.mapineq.org/functions/postgisftw.get_xy_data/items.json?_level=2&_predictor_year=2018&_outcome_year=2018&X_JSON={"source":"TGS00010","conditions":[{"field":"isced11","value":"TOTAL"},{"field":"unit","value":"PC"},{"field":"age","value":"Y_GE15"},{"field":"sex","value":"T"},{"field":"freq","value":"A"}]}&Y_JSON={"source":"DEMO_R_MLIFEXP","conditions":[{"field":"unit","value":"YR"},{"field":"age","value":"Y_LT1"},{"field":"sex","value":"T"},{"field":"freq","value":"A"}]}&limit=1500'
 )
 ```
 


### PR DESCRIPTION
Hey @niekvanruler. I updated the html that will make the documentation at https://docs.mapineq.org/api_technical_docs match your revision of https://mapineq.org/data-users. The public website will update automatically when we merge this pull request into the `main` branch. 

I also revised https://mapineq.org/data-users to be an overview written for a general audience that links to the technical documentation. 

Two questions for you to consider before approving this pull request:  
1. I attempted to embed our [webinar video](https://www.youtube.com/watch?v=UdB4Qe3o2Lk) into the WordPress page at https://mapineq.org/data-users (see first sentence of Learning Resources section). However, the YouTube embed block in WordPress did not work as intended. It only generated a url in text format with no video embedded. So, I didn't embed the video. Do you know how to do that?
2. Are we sure that the API endpoint `get_x_data` should return values for `outcome_year` and `predictor_year`? It doesn't seem intuitive that you would return two years when only a single dataset is being queried for a single year. 

Closes #161 